### PR TITLE
feat: remove ignore directories which already has been deleted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
-langs/
-logos/
-logo/
 src/api/


### PR DESCRIPTION
Some files which already has been removed from the project still remains in the .gitignore file