### PR TITLE
fix: identifiers now can be parsed at functions bodies

### DIFF
--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -224,9 +224,10 @@ export default class Parser {
         else
           returnExpression = this.parseReturn(scope)
       else {
-        const parsedObj = this.parseStatement(scope, false)
-
-        if (parsedObj instanceof exp.EntityAST || parsedObj instanceof exp.FunctionAST) {
+        if (this.cursor.currentTok.type === "IdentifierName")
+          this.parseIdentifier(scope)
+        else {
+          const parsedObj = this.parseStatement(scope, false)
           this.addToScope(scope, parsedObj.getName, parsedObj)
         }
       }
@@ -696,6 +697,7 @@ export default class Parser {
       this.scrapReferenceError(this.cursor.currentTok)
 
     this.nextToken() // eat the identifier
+
     return new exp.ExpressionAST()
   }
 
@@ -766,21 +768,21 @@ export default class Parser {
         case Keywords.CLASS: return this.parseClass(scope)
         case Keywords.MODULE: return this.parseModule(scope)
   
-        default: this.scrapParseError(`'${this.cursor.currentTok.content}' does not appear to be a statement`)
+        default: this.scrapParseError(`'${this.cursor.currentTok.content}' does not appear to be a valid primary statement`)
       }
     } else {
-      switch (this.cursor.currentTok.content) {
-        case Keywords.FN: return this.parseFunction(false, false, scope)
-        case Keywords.CONST: return this.parseConst(scope)
-        case Keywords.VAR: return this.parseVar(scope)
-  
-        default: {
-          const message = this.cursor.currentTok.type === "Statement" ?
-            `'${this.cursor.currentTok.content}' is a primary statement and is not allowed here
-            Learn more at: https://lang.scrapgames.com/tutorial/primary_statements` :
-            `'${this.cursor.currentTok.content}' does not appear to be a statement`
-            this.scrapParseError(message)
+      switch (this.cursor.currentTok.type) {
+        case "Statement": {
+          switch (this.cursor.currentTok.content) {
+            case Keywords.FN: return this.parseFunction(false, false, scope)
+            case Keywords.CONST: return this.parseConst(scope)
+            case Keywords.VAR: return this.parseVar(scope)
+
+            default: return this.scrapParseError(`'${this.cursor.currentTok.content}' is not allowed here`)
+          }
         }
+
+        default: this.scrapParseError(`The ${this.cursor.currentTok.type} '${this.cursor.currentTok.content}' is not allowed here, only statements and identifiers are permitted`)
       }
     }
   }

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -31,5 +31,5 @@ if (inArray("--repl", args)) {
     
     console.log(mainModule)
     parser.warnings.forEach(warning => console.warn("Warning: %s", warning))
-    //console.log("Main function scope\n", parser.functions[parser.functions.length - 1].getScope)
+    //console.log("Main function scope\n", mainFunction.getScope)
 }

--- a/tests/tiny.scrap
+++ b/tests/tiny.scrap
@@ -1,7 +1,17 @@
 module Mod {
   const modConstant = "I'm a constant inside a module called 'Mod'"
+
+  fn modFunction() {
+  }
 }
+
+fn log(message: String, args: ...any) {}
+
+const console = { log: log }
 
 fn main() {
   const myConstant = 10
+  console
+  console
+  log
 }


### PR DESCRIPTION
This PR gives the parser the possibility to allows put `IdentifiersName` token type in function body.

Previous to this change:
 - Calling a function was impossible since function calls involve use a `IdentifierName`
 - Reference variables. e.g: call a function that belongs to a object

Recreation of the problem:
```scrap
fn log(message: String) {}

fn main() {
    log("Hello, World!") // here we got a `ParsingError`, because to call `log` we are using a `IdentifierName`
}
```