### PR TITLE
feat: integers literal with a base different to 10 now can be typed in literal way

### DIFF
--- a/src/parser/parser-utils.ts
+++ b/src/parser/parser-utils.ts
@@ -34,21 +34,21 @@ export function parseFloatNumber(this: Parser) {
 
   // TODO: still needs to be good
 export function parseBinary(this: Parser) {
-    const binaryLiteralExp = new exp.IntegerExpression(parseFloat(this.cursor.currentTok.content))
+    const binaryLiteralExp = new exp.IntegerExpression(parseInt(this.cursor.currentTok.content, 2))
 
     this.nextToken()
     return binaryLiteralExp
 }
 
 export function parseOctal(this: Parser) {
-    const octalLiteralExp = new exp.IntegerExpression(parseFloat(this.cursor.currentTok.content))
+    const octalLiteralExp = new exp.IntegerExpression(parseInt(this.cursor.currentTok.content, 8))
 
     this.nextToken()
     return octalLiteralExp
 }
 
 export function parseHexa(this: Parser) {
-    const hexaLiteralExp = new exp.IntegerExpression(parseFloat(this.cursor.currentTok.content))
+    const hexaLiteralExp = new exp.IntegerExpression(parseInt(this.cursor.currentTok.content, 16))
 
     this.nextToken()
     return hexaLiteralExp

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -747,6 +747,9 @@ export default class Parser {
     switch (this.cursor.currentTok.type) {
       case "IdentifierName": return this.parseIdentifier(scope)
       case "NumericLiteral": return pUtils.parseNumber.call(this)
+      case "BinaryLiteral": return pUtils.parseBinary.call(this)
+      case "OctalLiteral": return pUtils.parseOctal.call(this)
+      case "HexaLiteral": return pUtils.parseHexa.call(this)
       case "FloatLiteral": return pUtils.parseFloatNumber.call(this)
       case "CharLiteral": return pUtils.parseChar.call(this)
       case "StringLiteral": return pUtils.parseString.call(this)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,12 @@ export function isAlpha(token: string) {
     return alphaRegex.test(token)
 }
 
+export function isHexadecimal(token: string) {
+    const numericValue = /[0-9a-fA-F]/
+
+    return numericValue.test(token)
+}
+
 /// Detects alphanumeric characters
 export function isAlphaNum(token: string) {
     const alphaNum = /[0-9a-zA-Z_]/
@@ -14,25 +20,7 @@ export function isAlphaNum(token: string) {
 
 /// Detects numeric characters, including decimals
 export function isNumeric(token: string) {
-    const numericRegex = /[0-9]/
-
-    return numericRegex.test(token)
-}
-
-export function isOctalLiteral(token: string) {
-    const numericRegex = /0o[0-9]/
-
-    return numericRegex.test(token)
-}
-
-export function isBinaryLiteral(token: string) {
-    const numericRegex = /0b[0-9]/
-
-    return numericRegex.test(token)
-}
-
-export function isHexaLiteral(token: string) {
-    const numericRegex = /0x[0-9]/
+    const numericRegex = /[0-9._]/
 
     return numericRegex.test(token)
 }
@@ -49,7 +37,7 @@ export function isSpace(token: string) {
  * @returns true, if `item` exists, false in other case
  */
 export function inArray(item: unknown, array: unknown[]): boolean {
-    return array.find(e => e === item) !== undefined
+    return array.some(e => e === item)
 }
 
 export abstract class Cursor<T> {

--- a/tests/tiny.scrap
+++ b/tests/tiny.scrap
@@ -1,17 +1,5 @@
-module Mod {
-  const modConstant = "I'm a constant inside a module called 'Mod'"
-
-  fn modFunction() {
-  }
-}
-
-fn log(message: String, args: ...any) {}
-
-const console = { log: log }
-
 fn main() {
-  const myConstant = 10
-  console
-  console
-  log
+  const myConstant = 0b1011
+
+  const sum = 0x100
 }

--- a/tests/tiny.scrap
+++ b/tests/tiny.scrap
@@ -1,5 +1,8 @@
 fn main() {
-  const myConstant = 0b1011
-
-  const sum = 0x100
+  const myConstant1 = 0xb
+  const myConstant2 = 0xb_bbb_ff100
+  
+  const myConstant3 = 0b1011
+  const myConstant4 = 0b10_1110011
+  const myConstant5 = 0o7771_77
 }


### PR DESCRIPTION
Numeric (integers) typed in a literal way, can now specific the base by type a special syntax before the numeric value.

## Binary literals
To declare an integer number using binary syntax. You must type the number using only `1` and `0` numbers

Example to declare a integer variable with value _11_: `const num = 0b1011`

## Octal literals
To declare an integer number using octal syntax. You must type the number using numeric values in a range between 0 and 7 (inclusive ranges)

Example to declare an integer variable with value _11_: `const num = 0o13`

## Hexadecimal literals
To declare an integer number using hexadecimal syntax. you must type the number using value in a range between 0 and 9.
Since hexadecimal has a base 16, reach this value is possible using letters from A to F

Example to declare an integer variable with value _11_: `const num = 0xb`

> Every case that implies to use alphabetics characters, can be used both as lower-case and upper-case characters.