### PR TITLE
feat: parser pases identifiers which are functions calls

### DIFF
--- a/src/lang/scope.ts
+++ b/src/lang/scope.ts
@@ -32,6 +32,20 @@ export class Scope {
     }
 
     /**
+     * Gets the value stored in `this` scope or parents scopes of `this`
+     * @param name Name of the variable (or entity)
+     * @returns The variable, if has been stored using `addEntry`, undefined otherwise
+     */
+    public getReference(name: string): ValidEntities | undefined {
+        if (this.scopedEntities.get(name) !== undefined)
+            return this.scopedEntities.get(name)
+        else if (this.parentScope !== null)
+            return this.parentScope.getReference(name)
+        else
+            return undefined
+    }
+
+    /**
      * Adds an entry to the current scope object
      * @param name Name of the entry
      * @param value Value of the entry

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -21,7 +21,7 @@ if (inArray("--repl", args)) {
     do {
         parser.parsePrimary(parser.mainModule.getScope)
     } while (!parser.cursor.isEOF())
-    
+
     console.log("\n")
     
     const mainFunction = parser.functions.find(func => func.getName === "main")
@@ -29,7 +29,7 @@ if (inArray("--repl", args)) {
     if (!mainFunction)
         throw new CompilationError("Missing program entrypoint (main function)")
     
-    console.log(mainModule)
+    //console.log(mainModule)
     parser.warnings.forEach(warning => console.warn("Warning: %s", warning))
-    //console.log("Main function scope\n", mainFunction.getScope)
+    console.log("Main function scope:\n", mainFunction.getScope.getScopedEntities)
 }

--- a/tests/tiny.scrap
+++ b/tests/tiny.scrap
@@ -1,8 +1,7 @@
+fn aFunction(param1: String) {}
+
 fn main() {
   const myConstant1 = 0xb
-  const myConstant2 = 0xb_bbb_ff100
-  
-  const myConstant3 = 0b1011
-  const myConstant4 = 0b10_1110011
-  const myConstant5 = 0o7771_77
+
+  const myReturn = aFunction("argument")
 }


### PR DESCRIPTION
The parser is no capable to parse function calls with a syntax similar to the next example

```scrap
fn aFunction(param1: String) {}

fn main() {
    aFunction("argument")
}
```

The parser also crash if a variable (const or var) that is not a function, is called as such

```scrap
const aConstant = 0x10

fn main() {
    aConstant() // will throw a ParsingError, becase `aConstant` is not a function
}
```