### PR TITLE
feat: ast can store primary statements instead of simply logging them

### DIFF
--- a/src/ast/Expressions.ts
+++ b/src/ast/Expressions.ts
@@ -163,6 +163,7 @@ export class DeclarationAST extends EntityAST {
     }
 
     public get getAssignedValue() { return this.assignedValue }
+    public set setAssignedValue(newValue: ExpressionAST) { this.assignedValue = newValue }
 }
 
 export class ModuleAST extends EntityAST {

--- a/src/ast/ast.ts
+++ b/src/ast/ast.ts
@@ -1,13 +1,27 @@
-import { EntityAST, ExpressionAST } from "./Expressions.ts"
+import Parser from "../parser/parser.ts";
+import { EntityAST, FunctionAST } from "./Expressions.ts"
 
 export default class AST {
-    private body: (ExpressionAST | EntityAST)[]
+    private body: (FunctionAST | EntityAST)[]
 
-    public constructor() {
+    public constructor(parser: Parser) {
         this.body = []
+        while (parser.cursor.isEOF()) {
+            this.body.push(parser.parsePrimary(parser.mainModule.getScope))
+        }
     }
 
-    public pushNode(node: ExpressionAST | EntityAST) {
+    public pushNode(node: FunctionAST | EntityAST) {
         this.body.push(node)
+    }
+
+    public static from(parser: Parser): AST {
+        const ast = new this(parser)
+
+        while (!parser.cursor.isEOF()) {
+            ast.pushNode(parser.parsePrimary(parser.mainModule.getScope))
+        }
+
+        return ast
     }
 }

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -16,7 +16,7 @@ import type { ScrapClassMethod, ScrapClassProperty, ScrapParam, AccessorModifier
 import ParsingError from "./parser-error.ts"
 import ParserCursor from "./parser-cursor.ts"
 import * as pUtils from "./parser-utils.ts"
-import AST from "../ast/ast.ts"
+//import AST from "../ast/ast.ts"
 import { inArray } from "../utils.ts"
 import { BINARY_OPERATORS_PRECEDENCE } from "../ast/Expressions.ts"
 
@@ -55,7 +55,7 @@ export default class Parser {
   warnings: string[]
   functions: exp.FunctionAST[]
   mainModule: exp.ModuleAST
-  ast: AST
+  //ast: AST
 
   public constructor(lexer: Lexer) {
     this.lexer = lexer
@@ -63,7 +63,7 @@ export default class Parser {
     this.warnings = []
     this.functions = []
     this.mainModule = new exp.ModuleAST("MainModule", createEmptyScope(null, "MainModule"))
-    this.ast = new AST()
+    //this.ast = new AST(this)
 
     this.cursor.currentTok = this.cursor.consume() // gives an initial value to the parser
   }

--- a/tests/tiny.scrap
+++ b/tests/tiny.scrap
@@ -1,5 +1,7 @@
 fn aFunction(param1: String) {}
 
+const mySum = 0b10
+
 fn main() {
   const myConstant1 = 0xb
 


### PR DESCRIPTION
This PR fixs my previous PR: #23

Which describes the next functionality:


The AST class now can store the statements returned by `parsePrimary`

This is only a 'snapshot'. In the future, the AST will store each statement or expression in the program, but at the moment it's a good begin.


