### PR TITLE
refactor: Added interpreter constructor

### DIFF
--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -1,5 +1,8 @@
+import AST from "./ast/ast.ts"
 import _Parser from "./parser/parser.ts"
 
 export class Interpreter {
+    public constructor(ast: AST) {
 
+    }
 }

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -37,7 +37,7 @@ export function repl() {
             lexer.alsoScan("repl", input)
             parser.restart()
             try {
-                console.log(parser.parsePrimary())
+                console.log(parser.parsePrimary(parser.mainModule.getScope))
             } catch (error) {
                 console.error("error:\n %s", error)
             }

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -4,32 +4,26 @@ import CompilationError from "../src/lang/compile-error.ts"
 
 import { inArray } from "../src/utils.ts"
 import { repl } from "../src/repl.ts"
-
-const fileName = "./tests/tiny.scrap"
-
-const file = await Deno.readTextFile(fileName)
-const lex = new Lexer(file, fileName)
-
-const parser = new Parser(lex)
-const mainModule = parser.mainModule
+import AST from "../src/ast/ast.ts"
 
 const args = Deno.args
 
 if (inArray("--repl", args)) {
     repl()
 } else {
-    do {
-        parser.parsePrimary(parser.mainModule.getScope)
-    } while (!parser.cursor.isEOF())
 
-    console.log("\n")
-    
+    const fileName = "./tests/tiny.scrap"
+    const file = await Deno.readTextFile(fileName)
+
+    const lex = new Lexer(file, fileName)
+    const parser = new Parser(lex)
+    const ast = AST.from(parser)
+
     const mainFunction = parser.functions.find(func => func.getName === "main")
     
     if (!mainFunction)
         throw new CompilationError("Missing program entrypoint (main function)")
     
-    //console.log(mainModule)
+    console.log(ast)
     parser.warnings.forEach(warning => console.warn("Warning: %s", warning))
-    console.log("Main function scope:\n", mainFunction.getScope.getScopedEntities)
 }


### PR DESCRIPTION
This PR contains:
 - a constructor without functionality btw
 - Moves the read of the file at `index.ts` to the else statement. In this way, we avoid to reads a file unnecesarely if `--repl` parameter is passed to the program