### PR TITLE
refactor: Separating native functions and native modules from modules and functions declared at .scrap files (defined by the user)

### DIFF
--- a/src/lang/expressions.ts
+++ b/src/lang/expressions.ts
@@ -352,26 +352,36 @@ export class DefinedModule extends ScrapModule {
  */
 export class ScrapFunction extends ScrapValue {
     private name: string
+
+    public constructor(name: string) {
+        super(undefined)
+        this.name = name
+    }
+
+    public get getName() { return this.name }
+}
+
+export class DefinedFunction extends ScrapFunction {
     private params: ScrapParam[]
     private body: (ScrapValue | Entity)[]
     private scope: Scope
     private returnExpression: ScrapValue
 
     public constructor(name: string, params: ScrapParam[], body: (ScrapValue | Entity)[], scope: Scope, returnExpression: ScrapValue) {
-        super(undefined)
-        this.name = name
+        super(name)
         this.params = params
         this.scope = scope
         this.body = body
         this.returnExpression = returnExpression
     }
 
-    public get getName() { return this.name }
+
     public get getParams() { return this.params }
     public get getBody() { return this.body }
     public get getScope() { return this.scope }
     public get getReturnType() { return this.returnExpression }
 
+    public set setScope(newScope: Scope) { this.scope = newScope }
     public set setReturnType(returnValue: ScrapValue) { this.returnExpression = returnValue }
 }
 
@@ -380,12 +390,15 @@ export class ScrapFunction extends ScrapValue {
  */
 export class ScrapNative extends ScrapFunction {
     private action: (...args: ScrapValue[]) => ScrapValue
+    private argsCount: number | true
 
-    public constructor(name: string, params: ScrapParam[], scope: Scope, action: (...args: ScrapValue[]) => ScrapValue) {
-        super(name, params, [], scope, new ScrapUndefined())
+    public constructor(name: string, argsCount: number | true, action: (...args: ScrapValue[]) => ScrapValue) {
+        super(name)
+        this.argsCount = argsCount
         this.action = action
     }
 
+    public get getArgsCount() { return this.argsCount }
     public get getAction() { return this.action }
 }
 

--- a/src/lang/expressions.ts
+++ b/src/lang/expressions.ts
@@ -321,7 +321,22 @@ export class ScrapModule extends Entity {
         vals.forEach(val => this.scope.addEntry(val.name, val.value))
     }
 
+    public get getName() { return this.name }
+
+    public set setScope(newScope: Scope) { this.scope = newScope }
+
     public get getScope() { return this.scope }
+}
+
+export class DefinedModule extends ScrapModule {
+    private body: (Entity | ScrapFunction)[]
+
+    public constructor(name: string, body: (Entity | ScrapFunction)[], scope: Scope) {
+        super(name, scope)
+        this.body = body
+    }
+
+    public get getBody() { return this.body }
 }
 
 /**

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -338,9 +338,9 @@ export default class Parser {
    * Same as `parseBody`, in this case, a module could contains another module.
    * By this reason, this reason, the body module parsing is separated from the normal `parseBody`
    */
-  private parseModuleBody(scope: Scope) {
+  private parseModuleBody(scope: Scope, body: (exp.Entity | exp.ScrapFunction)[]) {
     while (this.cursor.currentTok.content !== Tokens.RBRACE) {
-      this.parsePrimary(scope) // does not need to explcitly add to the scope, because parsePrimary already adds to the passed scope
+      body.push(this.parsePrimary(scope)) // does not need to explcitly add to the scope, because parsePrimary already adds to the passed scope
     }
   }
 
@@ -412,11 +412,12 @@ export default class Parser {
     this.nextToken() // eat '{'
 
     const mScope = createEmptyScope(scope, moduleName)
-    this.parseModuleBody(mScope)
+    const body: (exp.Entity | exp.ScrapFunction)[] = []
+    this.parseModuleBody(mScope, body)
 
     this.nextToken() // eat '}'
 
-    const newModule = new exp.ScrapModule(moduleName, mScope)
+    const newModule = new exp.DefinedModule(moduleName, body, mScope)
 
     this.ast.pushNode(newModule)
     return newModule

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -327,7 +327,7 @@ export default class Parser {
 
     this.nextToken() // eat '}'
 
-    const newFunction = new exp.ScrapFunction(fName, params, functionBody, fScope, returnExpression)
+    const newFunction = new exp.DefinedFunction(fName, params, functionBody, fScope, returnExpression)
 
     this.functions.push(newFunction)
     this.ast.pushNode(newFunction)
@@ -596,7 +596,7 @@ export default class Parser {
     const constructor = cScope.getReference("constructor")
 
     if (constructor)
-      (constructor as exp.ScrapFunction).setReturnType = new exp.ScrapString(className)
+      (constructor as exp.DefinedFunction).setReturnType = new exp.ScrapString(className)
 
     const newClass = new exp.ScrapClass(className, classEntities, cScope, constructor !== undefined)
 


### PR DESCRIPTION
Since native functions or native modules unlike the same values that has been declared at .scrap files. Is convenient to separate de fields of them to have a better control at the moment to parse this objects

### > This change may change at the future. Specially for user declared functions, which parameters may be necessary to keep in mind in future updates