### PR TITLE
fix: parseFunctionParams was not returning the correct value

### DIFF
--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -487,7 +487,7 @@ export default class Parser implements Reader<Token, Tokens> {
     }
 
     this.eat(Tokens.RPAREN)
-    return []
+    return params
   }
 
   /**


### PR DESCRIPTION
This PR fixes the parseFunctionParams method, which was returning an empty array instead of an array containing the parsed parameters.