### PR TITLE
feat: exists function returning true or undefined

### DIFF
--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -142,6 +142,10 @@ export default class Parser implements Reader<Token, Tokens> {
     return current
   }
 
+  private exists(type: Tokens): Undefinedable<true> {
+    return this.current.is(type) || undefined
+  }
+
   /**
    * Conditionally consumes the current token if it matches the expected type.
    * @param type Token type to check.


### PR DESCRIPTION
Added a function that returns true or undefined if the passed token matches this.current.
This makes the code cleaner by avoiding the need for a weird transformation from false to undefined, like this:
```ts
this.current.is(...) || undefined && ...
```