### PR TITLE
Rename "Undefinedable" by "Maybe"

### DIFF
--- a/src/frontend/ast/nodes/declarations.ts
+++ b/src/frontend/ast/nodes/declarations.ts
@@ -7,12 +7,12 @@
  * `DeclarationNode`, which provides the common structure for all declarations.
  */
 
-import { Undefinedable } from "@/typings.ts"
-import { Tokens }        from "@frontend/tokens/tokens.ts"
-import { Position }      from "@frontend/position.ts"
-import { ASTNode }       from "@frontend/ast/ast.ts"
-import { Expression }    from "@frontend/ast/nodes/expressions.ts"
-import { Statement }     from "@frontend/ast/nodes/statements.ts"
+import { Maybe }      from "@/typings.ts"
+import { Tokens }     from "@frontend/tokens/tokens.ts"
+import { Position }   from "@frontend/position.ts"
+import { ASTNode }    from "@frontend/ast/ast.ts"
+import { Expression } from "@frontend/ast/nodes/expressions.ts"
+import { Statement }  from "@frontend/ast/nodes/statements.ts"
 import { Function, FunctionFlags, Param } from "@frontend/ast/nodes/functions.ts"
 
 /**
@@ -111,7 +111,7 @@ export class FunctionDecl extends NameableDecl {
 export class FunctionDef extends NameableDecl implements Function {
   public constructor(
     public params: Param[], public body: Statement[],
-    public flag: Undefinedable<FunctionFlags>, name: string,
+    public flag: Maybe<FunctionFlags>, name: string,
     start: Position, end: Position,
   ) {
     super(name, DeclarationKind.FunctionDef, start, end)

--- a/src/frontend/ast/nodes/expressions.ts
+++ b/src/frontend/ast/nodes/expressions.ts
@@ -10,10 +10,10 @@
  * interpretation or code generation.
  */
 
-import { Undefinedable }      from "@/typings.ts"
-import { Position }           from "@frontend/position.ts"
-import { Token }              from "@frontend/tokens/tokens.ts"
-import { ASTNode }            from "@frontend/ast/ast.ts"
+import { Maybe }    from "@/typings.ts"
+import { Position } from "@frontend/position.ts"
+import { Token }    from "@frontend/tokens/tokens.ts"
+import { ASTNode }  from "@frontend/ast/ast.ts"
 import { Case, Default, Statement }       from "@frontend/ast/nodes/statements.ts"
 import { Function, FunctionFlags, Param } from "@frontend/ast/nodes/functions.ts"
 
@@ -107,7 +107,7 @@ export class Binary extends Expression {
 export class FunctionExpr extends Expression implements Function {
   public constructor(
     public name: string, public params: Param[],
-    public body: Statement[], public flag: Undefinedable<FunctionFlags>,
+    public body: Statement[], public flag: Maybe<FunctionFlags>,
     start: Position, end: Position,
   ) {
     super(ExpressionKind.Function, start, end)
@@ -124,7 +124,7 @@ export class Match extends Expression {
   public constructor(
     public subjet: Expression,
     public body: Case[],
-    public fallThrough: Undefinedable<Default>,
+    public fallThrough: Maybe<Default>,
     start: Position, end: Position
   ) {
     super(ExpressionKind.Match, start, end)

--- a/src/frontend/ast/nodes/functions.ts
+++ b/src/frontend/ast/nodes/functions.ts
@@ -1,16 +1,16 @@
-import { Undefinedable } from "@/typings.ts"
-import { Position }      from "@frontend/position.ts"
-import { Tokens }        from "@frontend/tokens/tokens.ts"
-import { ASTNode }       from "@frontend/ast/ast.ts"
-import { TType }         from "@frontend/ast/nodes/types.ts"
-import { Statement }     from "@frontend/ast/nodes/statements.ts"
+import { Maybe }     from "@/typings.ts"
+import { Position }  from "@frontend/position.ts"
+import { Tokens }    from "@frontend/tokens/tokens.ts"
+import { ASTNode }   from "@frontend/ast/ast.ts"
+import { TType }     from "@frontend/ast/nodes/types.ts"
+import { Statement } from "@frontend/ast/nodes/statements.ts"
 
 /**
  * Interface representing common fields to both declarations and expressions.
  */
 export interface Function {
   name: string, params: Param[],
-  body: Statement[], flag: Undefinedable<FunctionFlags>
+  body: Statement[], flag: Maybe<FunctionFlags>
 }
 
 /**

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -1,7 +1,7 @@
-import { SyntaxError }    from "@/errors.ts"
-import { Undefinedable }  from "@/typings.ts"
-import { Position }       from "@frontend/position.ts"
-import type { Reader }    from "@frontend/typings.ts"
+import { SyntaxError }  from "@/errors.ts"
+import { Maybe }        from "@/typings.ts"
+import { Position }     from "@frontend/position.ts"
+import type { Reader }  from "@frontend/typings.ts"
 import { Token, Tokens, TOKEN_MAP, stringify } from "@frontend/tokens/tokens.ts"
 import Lexer             from "./lexer.ts"
 import * as ast          from "@frontend/ast/nodes/index.ts"
@@ -180,12 +180,12 @@ export default class Parser implements Reader<Token, Tokens> {
    * @returns Object { flag, name, params, hasArrow }
    */
   private parseFunctionSign():
-    { flag: Undefinedable<FunctionFlags>,
-      name: Undefinedable<string>,
+    { flag: Maybe<FunctionFlags>,
+      name: Maybe<string>,
       params: ast.functions.Param[],
       hasArrow: boolean
     } {
-    const flag = (this.wheter(Tokens.INLINE) || this.wheter(Tokens.ASYNC))?.type as Undefinedable<FunctionFlags>
+    const flag = (this.wheter(Tokens.INLINE) || this.wheter(Tokens.ASYNC))?.type as Maybe<FunctionFlags>
     if (!this.wheter(Tokens.FN))
       this.syntaxError("Functions can only has one flag")
 
@@ -514,7 +514,7 @@ export default class Parser implements Reader<Token, Tokens> {
    */
   private parseFunctionDef(
     start: Position,
-    flag: Undefinedable<FunctionFlags>,
+    flag: Maybe<FunctionFlags>,
     name: string,
     params: ast.functions.Param[]
   ): ast.declarations.FunctionDef {
@@ -697,7 +697,7 @@ export default class Parser implements Reader<Token, Tokens> {
     this.eat(Tokens.LBRACE)
 
     const body: ast.statements.Case[] = []
-    let fallThrough: Undefinedable<ast.statements.Default> = undefined
+    let fallThrough: Maybe<ast.statements.Default> = undefined
     while (!this.current.is(Tokens.RBRACE)) {
       const stmt = this.parseCaseStmt(this.Position)
       switch (true) {
@@ -724,8 +724,8 @@ export default class Parser implements Reader<Token, Tokens> {
    */
   private parseFunctionExpr(
     start: Position,
-    flag: Undefinedable<FunctionFlags>,
-    name: Undefinedable<string>,
+    flag: Maybe<FunctionFlags>,
+    name: Maybe<string>,
     params: ast.functions.Param[],
     hasArrow: boolean
   ): ast.expressions.FunctionExpr {

--- a/src/frontend/tokens/tokens.ts
+++ b/src/frontend/tokens/tokens.ts
@@ -1,4 +1,4 @@
-import { Undefinedable } from "@/typings.ts"
+import { Maybe }    from "@/typings.ts"
 import { Position } from "@frontend/position.ts"
 
 /**
@@ -346,7 +346,7 @@ export class Token {
     return new this(type, content, pos.copy())
   }
 
-  public is(maybe: Tokens): Undefinedable<true> {
+  public is(maybe: Tokens): Maybe<true> {
     return this.type === maybe || undefined
   }
 

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -1,4 +1,4 @@
-export type Undefinedable<T> = T | undefined
+export type Maybe<T> = T | undefined
 
 /**
  * Represents a chainable environment for symbol resolution.


### PR DESCRIPTION
Although "Undefinedable" is sufficiently descriptive as far as how it acts in the source code. **Maybe** has advantages like:

- Is a shorter word
- Represents better the possible absence of a value
- More descriptive in programming contexts
- More "modern"(? compared to other programming languages